### PR TITLE
chore: renaming imports and project path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG ARCH
 
 FROM docker.io/library/golang:1.20-alpine as build
 RUN apk add --no-cache bash curl make openssl
-WORKDIR /go/src/github.com/emosbaugh/helmbin
+WORKDIR /go/src/github.com/replicatedhq/helmbin
 COPY . .
 ARG VERSION="dev"
 RUN make build
@@ -15,7 +15,7 @@ RUN apk add --no-cache bash coreutils curl findutils iptables tini
 ENV KUBECONFIG=/var/lib/replicated/k0s/pki/admin.conf
 
 ADD docker-entrypoint.sh /entrypoint.sh
-COPY --from=build /go/src/github.com/emosbaugh/helmbin/bin/helmbin /usr/local/bin/helmbin
+COPY --from=build /go/src/github.com/replicatedhq/helmbin/bin/helmbin /usr/local/bin/helmbin
 
 ENTRYPOINT ["/sbin/tini", "--", "/bin/sh", "/entrypoint.sh" ]
 

--- a/Makefile
+++ b/Makefile
@@ -104,4 +104,4 @@ golangci-lint:
 		sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) v$(golangci-lint_version)
 
 go.sum: go.mod
-	$(GO) mod tidy && touch -c -- '$@'
+	go mod tidy && touch -c -- '$@'

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Use "helmbin [command] --help" for more information about a command.
 
 ```bash
 $ make build
-go build -gcflags "all=-trimpath=/home/ethan/go/src/github.com/emosbaugh" -asmflags "all=-trimpath=/home/ethan/go/src/github.com/emosbaugh" -ldflags " -X main.goos=linux -X main.goarch=amd64 -X main.gitCommit=1a6e487bb4bcb5049c448983758912afbdb9d1c2 -X main.buildDate=2023-05-24T21:42:34Z " -tags='' -o bin/helmbin ./cmd/helmbin
+go build -gcflags "all=-trimpath=/home/ethan/go/src/github.com/replicatedhq" -asmflags "all=-trimpath=/home/ethan/go/src/github.com/replicatedhq" -ldflags " -X main.goos=linux -X main.goarch=amd64 -X main.gitCommit=1a6e487bb4bcb5049c448983758912afbdb9d1c2 -X main.buildDate=2023-05-24T21:42:34Z " -tags='' -o bin/helmbin ./cmd/helmbin
 ```
 
 ## Running

--- a/cmd/helmbin/main.go
+++ b/cmd/helmbin/main.go
@@ -9,7 +9,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/emosbaugh/helmbin/pkg/cli"
+	"github.com/replicatedhq/helmbin/pkg/cli"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/emosbaugh/helmbin
+module github.com/replicatedhq/helmbin
 
 go 1.20
 

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -49,7 +49,7 @@ $(smoketests): .footloose-alpine.stamp
 $(smoketests): TEST_PACKAGE ?= $(subst check-,,$@)
 $(smoketests):
 	K0S_PATH='$(HELMBIN_PATH)' \
-	go test -count=1 -v -timeout $(TIMEOUT) github.com/emosbaugh/helmbin/inttest/$(TEST_PACKAGE)
+	go test -count=1 -v -timeout $(TIMEOUT) github.com/replicatedhq/helmbin/inttest/$(TEST_PACKAGE)
 
 .PHONY: clean
 clean:

--- a/pkg/cli/install.go
+++ b/pkg/cli/install.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/emosbaugh/helmbin/pkg/config"
 	"github.com/k0sproject/k0s/cmd/install"
 	"github.com/k0sproject/k0s/cmd/start"
+	"github.com/replicatedhq/helmbin/pkg/config"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/cli/kubeconfig.go
+++ b/pkg/cli/kubeconfig.go
@@ -15,7 +15,7 @@ import (
 	"github.com/k0sproject/k0s/pkg/constant"
 	"github.com/spf13/cobra"
 
-	"github.com/emosbaugh/helmbin/pkg/config"
+	"github.com/replicatedhq/helmbin/pkg/config"
 )
 
 // NewCmdKubeconfig returns a cobra command for getting the kubeconfig

--- a/pkg/cli/kubectl.go
+++ b/pkg/cli/kubectl.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/component-base/logs"
 	kubectl "k8s.io/kubectl/pkg/cmd"
 
-	"github.com/emosbaugh/helmbin/pkg/config"
+	"github.com/replicatedhq/helmbin/pkg/config"
 )
 
 // NewCmdKubectl returns a cobra command for running kubectl

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -7,9 +7,9 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/emosbaugh/helmbin/pkg/config"
-	"github.com/emosbaugh/helmbin/pkg/controller"
-	"github.com/emosbaugh/helmbin/pkg/controller/manager"
+	"github.com/replicatedhq/helmbin/pkg/config"
+	"github.com/replicatedhq/helmbin/pkg/controller"
+	"github.com/replicatedhq/helmbin/pkg/controller/manager"
 )
 
 // NewCmdRun returns a cobra command for running a combined controller and worker node

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"fmt"
 
-	"github.com/emosbaugh/helmbin/pkg/version"
+	"github.com/replicatedhq/helmbin/pkg/version"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/controller/helm.go
+++ b/pkg/controller/helm.go
@@ -16,8 +16,8 @@ import (
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/release"
 
-	"github.com/emosbaugh/helmbin/pkg/config"
-	"github.com/emosbaugh/helmbin/static"
+	"github.com/replicatedhq/helmbin/pkg/config"
+	"github.com/replicatedhq/helmbin/static"
 )
 
 // Helm implement the component interface to run the Helm controller

--- a/pkg/controller/k0scontroller.go
+++ b/pkg/controller/k0scontroller.go
@@ -18,10 +18,10 @@ import (
 	kconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/yaml"
 
-	"github.com/emosbaugh/helmbin/pkg/assets"
-	"github.com/emosbaugh/helmbin/pkg/config"
-	"github.com/emosbaugh/helmbin/pkg/supervisor"
-	"github.com/emosbaugh/helmbin/static"
+	"github.com/replicatedhq/helmbin/pkg/assets"
+	"github.com/replicatedhq/helmbin/pkg/config"
+	"github.com/replicatedhq/helmbin/pkg/supervisor"
+	"github.com/replicatedhq/helmbin/static"
 )
 
 // K0sController implements the component interface to run the k0s controller.

--- a/pkg/controller/server.go
+++ b/pkg/controller/server.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/emosbaugh/helmbin/pkg/assets"
-	"github.com/emosbaugh/helmbin/pkg/config"
-	"github.com/emosbaugh/helmbin/pkg/server"
-	"github.com/emosbaugh/helmbin/static"
+	"github.com/replicatedhq/helmbin/pkg/assets"
+	"github.com/replicatedhq/helmbin/pkg/config"
+	"github.com/replicatedhq/helmbin/pkg/server"
+	"github.com/replicatedhq/helmbin/static"
 )
 
 // Server implement the component interface to run the helmbin server


### PR DESCRIPTION
Now that this repository ownership has been moved to `replicatedhq` org we have to rename all import paths replacing `emosbaugh` by`replicatedhq`.

No functional change has been introduced here.