### PR TITLE
feat: adding --no-prompt flag

### DIFF
--- a/cmd/helmvm/upgrade.go
+++ b/cmd/helmvm/upgrade.go
@@ -45,6 +45,13 @@ func canRunUpgrade(c *cli.Context) error {
 var upgradeCommand = &cli.Command{
 	Name:  "upgrade",
 	Usage: "Upgrade the local node",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "no-prompt",
+			Usage: "Do not prompt user when it is not necessary",
+			Value: false,
+		},
+	},
 	Action: func(c *cli.Context) error {
 		if err := canRunUpgrade(c); err != nil {
 			return err
@@ -74,7 +81,7 @@ var upgradeCommand = &cli.Command{
 		}
 		os.Setenv("KUBECONFIG", kcfg)
 		logrus.Infof("Upgrading addons")
-		if applier, err := addons.NewApplier(); err != nil {
+		if applier, err := addons.NewApplier(c.Bool("no-prompt")); err != nil {
 			return fmt.Errorf("unable to create applier: %w", err)
 		} else if err := applier.Apply(c.Context); err != nil {
 			return fmt.Errorf("unable to apply addons: %w", err)

--- a/pkg/addons/adminconsole/adminconsole.go
+++ b/pkg/addons/adminconsole/adminconsole.go
@@ -36,9 +36,14 @@ type AdminConsole struct {
 	config    *action.Configuration
 	logger    action.DebugLog
 	namespace string
+	prompt    bool
 }
 
 func (a *AdminConsole) askPassword() (string, error) {
+	if !a.prompt {
+		logrus.Warnf("Admin Console password set to: password")
+		return "password", nil
+	}
 	question := &survey.Password{Message: "Enter a new Admin Console password:"}
 	var pass string
 	for pass == "" {
@@ -155,12 +160,17 @@ func (a *AdminConsole) installedRelease(ctx context.Context) (*release.Release, 
 	return releases[0], nil
 }
 
-func New(namespace string, logger action.DebugLog) (*AdminConsole, error) {
+func New(namespace string, prompt bool, logger action.DebugLog) (*AdminConsole, error) {
 	env := cli.New()
 	env.SetNamespace(namespace)
 	config := &action.Configuration{}
 	if err := config.Init(env.RESTClientGetter(), namespace, "", logger); err != nil {
 		return nil, fmt.Errorf("unable to init configuration: %w", err)
 	}
-	return &AdminConsole{namespace: namespace, config: config, logger: logger}, nil
+	return &AdminConsole{
+		namespace: namespace,
+		config:    config,
+		logger:    logger,
+		prompt:    prompt,
+	}, nil
 }

--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -77,7 +77,7 @@ func (a *Applier) waitForKubernetes(ctx context.Context) error {
 }
 
 // NewApplier creates a new Applier instance with all addons registered.
-func NewApplier() (*Applier, error) {
+func NewApplier(prompt bool) (*Applier, error) {
 	k8slogger := zap.New(func(o *zap.Options) {
 		o.DestWriter = io.Discard
 	})
@@ -101,7 +101,7 @@ func NewApplier() (*Applier, error) {
 	}
 	applier.addons["openebs"] = obs
 	logger = logrus.WithField("addon", "adminconsole")
-	aconsole, err := adminconsole.New("helmvm", logger.Infof)
+	aconsole, err := adminconsole.New("helmvm", prompt, logger.Infof)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create admin console addon: %w", err)
 	}

--- a/pkg/infra/infra.go
+++ b/pkg/infra/infra.go
@@ -29,7 +29,7 @@ type Node struct {
 
 // Apply uses "terraform apply" to apply the infrastructe defined in the
 // directory passed as argument.
-func Apply(ctx context.Context, dir string) ([]Node, error) {
+func Apply(ctx context.Context, dir string, prompt bool) ([]Node, error) {
 	log, end := pb.Start()
 	outputs, err := runApply(ctx, dir, log)
 	if err != nil {
@@ -45,10 +45,13 @@ func Apply(ctx context.Context, dir string) ([]Node, error) {
 		return nil, fmt.Errorf("unable to process terraform output: %w", err)
 	}
 	printNodes(nodes)
+	if !prompt {
+		return nodes, nil
+	}
 	logrus.Info("You may want to take note of the output for later use")
-	prompt := &survey.Input{Message: "Press enter to proceed"}
+	question := &survey.Input{Message: "Press enter to proceed"}
 	var ignore string
-	if err := survey.AskOne(prompt, &ignore); err != nil {
+	if err := survey.AskOne(question, &ignore); err != nil {
 		return nil, fmt.Errorf("unable to ask for enter: %w", err)
 	}
 	return nodes, nil


### PR DESCRIPTION
With `--no-prompt` command line flag user can control if the installer should or not ask for confirmations. This is specially useful for when we start deploying this as part of the compatibility matrix.